### PR TITLE
Disable eslint rules owned by Prettier

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,6 @@ module.exports = {
   },
   rules: {
     // Possible Errors
-    'comma-dangle': 2,
     'no-cond-assign': 2,
     'no-console': 0,
     'no-constant-condition': 2,
@@ -40,7 +39,6 @@ module.exports = {
     'no-ex-assign': 2,
     'no-extra-boolean-cast': 2,
     'no-extra-parens': 0,
-    'no-extra-semi': 2,
     'no-func-assign': 2,
     'no-inner-declarations': 2,
     'no-invalid-regexp': 2,
@@ -63,7 +61,6 @@ module.exports = {
     curly: [2, 'all'],
     'default-case': 2,
     'dot-notation': 2,
-    'dot-location': [2, 'property'],
     eqeqeq: 2,
     'guard-for-in': 2,
     'no-alert': 2,
@@ -83,7 +80,6 @@ module.exports = {
     'no-labels': 2,
     'no-lone-blocks': 2,
     'no-loop-func': 2,
-    'no-multi-spaces': 2,
     'no-multi-str': 2,
     'no-native-reassign': 2,
     'no-new-func': 2,
@@ -107,7 +103,6 @@ module.exports = {
     'no-with': 2,
     radix: 2,
     'vars-on-top': 2,
-    'wrap-iife': 2,
     yoda: 2,
 
     // Strict Mode
@@ -137,40 +132,16 @@ module.exports = {
     'no-sync': 2,
 
     // Stylistic Issues
-    'block-spacing': [2, 'always'],
-    'brace-style': [2, '1tbs'],
-    'comma-spacing': [2, { before: false, after: true }],
-    'comma-style': [2, 'last'],
-    'eol-last': 2,
     'func-style': 0, // expressions vs declrations?
-    indent: [2, 2, { SwitchCase: 1 }],
-    'key-spacing': [2, { beforeColon: false, afterColon: true }],
     'linebreak-style': [2, 'unix'],
     'new-cap': 2,
-    'new-parens': 2,
     'no-lonely-if': 2,
-    'no-mixed-spaces-and-tabs': 2,
-    'no-multiple-empty-lines': [2, { max: 1 }],
     'no-nested-ternary': 2,
-    'no-spaced-func': 2,
-    'no-trailing-spaces': 2,
     'no-unneeded-ternary': 2,
-    'object-curly-spacing': [2, 'always'],
-    'operator-linebreak': [2, 'after'],
-    'padded-blocks': [2, 'never'],
-    quotes: [2, 'single'],
-    'semi-spacing': [2, { before: false, after: true }],
-    semi: [2, 'always'],
-    'space-before-blocks': [2, 'always'],
-    'space-before-function-paren': [2, 'never'],
-    'space-in-parens': [2, 'never'],
-    'space-infix-ops': 2,
     'spaced-comment': [2, 'always'],
 
     // ECMAScript 6
-    'arrow-spacing': [2, { before: true, after: true }],
     'constructor-super': 2,
-    'generator-star-spacing': [2, { before: false, after: true }],
     'no-class-assign': 2,
     'no-const-assign': 2,
     'no-dupe-class-members': 2,
@@ -209,19 +180,10 @@ module.exports = {
     'react/self-closing-comp': 2,
     'react/sort-comp': 2,
     'react/sort-prop-types': 0,
-    'react/jsx-wrap-multilines': 2,
     'react/jsx-boolean-value': 0,
-    'react/jsx-closing-bracket-location': [
-      2,
-      { selfClosing: 'tag-aligned', nonEmpty: 'after-props' }
-    ],
     'react/jsx-curly-spacing': 0, // [2, "never", { "allowMultiline": false }],
-    'react/jsx-equals-spacing': [2, 'never'],
     'react/jsx-filename-extension': [2, { extensions: ['.js'] }],
-    'react/jsx-first-prop-new-line': [2, 'multiline'],
     'react/jsx-handler-names': 0, // 2,
-    'react/jsx-indent': [2, 2],
-    'react/jsx-indent-props': [2, 2],
     'react/jsx-key': 2,
     'react/jsx-max-props-per-line': 0,
     'react/jsx-no-bind': 2,
@@ -231,9 +193,6 @@ module.exports = {
     'react/jsx-no-undef': 2,
     'react/jsx-pascal-case': 2,
     'react/jsx-sort-props': 0,
-    'react/jsx-tag-spacing': [2, {
-      beforeSelfClosing: 'always'
-    }],
     'react/jsx-uses-react': 2,
     'react/jsx-uses-vars': 2,
 
@@ -249,5 +208,5 @@ module.exports = {
     'import/export': 2
   },
   plugins: ['react', 'css-modules', 'import'],
-  extends: ['plugin:css-modules/recommended']
+  extends: ['plugin:css-modules/recommended', 'prettier']
 };

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "babel-eslint": "^7.2.3",
     "eslint": "^3.19.0",
+    "eslint-config-prettier": "^2.3.0",
     "eslint-import-resolver-node": "^0.3.0",
     "eslint-plugin-css-modules": "^2.7.1",
     "eslint-plugin-import": "^2.2.0",


### PR DESCRIPTION
**Note:** This change is not required if SKU does not support Prettier.

Eslint and Prettier overlaps in concerns. This change will disable all rules that Prettier will enforce. Avoiding any issues where prettier and eslint conflict.

eslint-config-prettier will disable any rules added by other configs
https://github.com/prettier/eslint-config-prettier

However rules explicitly added to the config need to be removed. These can be identified by command line
```
eslint --config index.js --print-config index.js | eslint-config-prettier-check
```

Results from above were removed until above command line confirmed pass.