### PR TITLE
Force module resolution to resolve from project root

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,6 @@
+const path = require('path');
+const root = require('find-root')(process.cwd());
+
 module.exports = {
   parser: 'babel-eslint',
   parserOptions: {
@@ -20,7 +23,7 @@ module.exports = {
   settings: {
     'import/resolver': {
       'node': {
-        'moduleDirectory': ['node_modules', '.']
+        'moduleDirectory': [root, path.join(root, 'node_modules')]
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sku",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "ESLint configuration used by SKU",
   "main": "index.js",
   "repository": {
@@ -20,6 +20,7 @@
     "eslint-import-resolver-node": "^0.3.0",
     "eslint-plugin-css-modules": "^2.7.1",
     "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-react": "^7.0.1"
+    "eslint-plugin-react": "^7.0.1",
+    "find-root": "^1.1.0"
   }
 }


### PR DESCRIPTION
This is to address inconsistent results we were receiving between IDE and terminal running of eslint as the working directory can differ between them. 