### PR TITLE
feat(rule): Enforce Usage of Spacing in Template Strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,6 +142,7 @@ module.exports = {
     'no-nested-ternary': 2,
     'no-unneeded-ternary': 2,
     'spaced-comment': [2, 'always'],
+    'template-curly-spacing': ['error', 'never'],
 
     // ECMAScript 6
     'constructor-super': 2,


### PR DESCRIPTION
Enforce Usage of Spacing in Template Strings [(template-curly-spacing)](https://eslint.org/docs/rules/template-curly-spacing)
---

The `--fix` option on the [command line](https://eslint.org/docs/user-guide/command-line-interface#fix) can automatically fix some of the problems reported by this rule.

We can embed expressions in template strings with using a pair of `${` and `}`.

This rule can force usage of spacing within the curly brace pair according to style guides.
```
{
    "template-curly-spacing": ["error", "never"]
}
```
`"never"` (by default) - Disallows spaces inside of the curly brace pair.

---

Examples of **incorrect** code for this rule with the default "never" option:

`hello, ${ people.name}!`;

Examples of **correct code** for this rule with the default `"never"` option:

`hello, ${people.name}!`;