### PR TITLE
ci(release): Use node v8 for semantic-release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ cache:
 notifications:
   email: false
 node_js:
-  - '7'
-  - '6'
+  - '8'
 before_script:
   - npm prune
 after_success:


### PR DESCRIPTION
Semantic release version `v^8` needs to run on node `v^8`