### PR TITLE
fix(rule): Remove template-curly-spacing rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,7 +142,6 @@ module.exports = {
     'no-nested-ternary': 2,
     'no-unneeded-ternary': 2,
     'spaced-comment': [2, 'always'],
-    'template-curly-spacing': ['error', 'never'],
 
     // ECMAScript 6
     'constructor-super': 2,


### PR DESCRIPTION
Some Eslint rules overlap with Prettier.
We previously removed rules that should be enforced by Prettier from eslint in
https://github.com/seek-oss/eslint-config-sku/pull/3

This is just a follow up to remove one more. Again using
`eslint --config index.js --print-config index.js | eslint-config-prettier-check`
to find all relevant rules.

See [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) for blacklist of rules.

In discussing this change the need for a `eslint-config-sku/format` that includes all of these formatting concerns was discussed but will be a separate change.