### PR TITLE
feat(format): Added 'sku/unpretty' feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ Then create a file named `.eslintrc` with following contents in the root folder 
 
 You can override the settings from `eslint-config-sku` by editing the `.eslintrc` file. Learn more about [configuring ESLint](http://eslint.org/docs/user-guide/configuring) on the ESLint website.
 
+## sku/unpretty
+
+The core sku config does not include formatting concerns.  
+It is recommended to use [Prettier](https://www.npmjs.com/package/prettier) to lint formatting concerns.  
+If you are not using Prettier and would like to enable formatting rules, use `sku/unpretty` in addition to the core `sku` config.  
+
+```js
+{
+  "extends": ["sku", "sku/unpretty"]
+}
+```
+
 ## License
 
 MIT.

--- a/unpretty/index.js
+++ b/unpretty/index.js
@@ -1,0 +1,50 @@
+module.exports = {
+  rules: {
+    'arrow-spacing': [2, { before: true, after: true }],
+    'block-spacing': [2, 'always'],
+    'brace-style': [2, '1tbs'],
+    'comma-dangle': 2,
+    'comma-spacing': [2, { before: false, after: true }],
+    'comma-style': [2, 'last'],
+    'dot-location': [2, 'property'],
+    'eol-last': 2,
+    indent: [2, 2, { SwitchCase: 1 }],
+    'generator-star-spacing': [2, { before: false, after: true }],
+    'key-spacing': [2, { beforeColon: false, afterColon: true }],
+    'new-parens': 2,
+    'no-extra-semi': 2,
+    'no-mixed-spaces-and-tabs': 2,
+    'no-multi-spaces': 2,
+    'no-multiple-empty-lines': [2, { max: 1 }],
+    'no-spaced-func': 2,
+    'no-trailing-spaces': 2,
+    'object-curly-spacing': [2, 'always'],
+    'operator-linebreak': [2, 'after'],
+    'padded-blocks': [2, 'never'],
+    quotes: [2, 'single'],
+    'semi-spacing': [2, { before: false, after: true }],
+    semi: [2, 'always'],
+    'space-before-blocks': [2, 'always'],
+    'space-before-function-paren': [2, 'never'],
+    'space-in-parens': [2, 'never'],
+    'space-infix-ops': 2,
+    'template-curly-spacing': ['error', 'never'],
+    'wrap-iife': 2,
+    'react/jsx-wrap-multilines': 2,
+    'react/jsx-closing-bracket-location': [
+      2,
+      { selfClosing: 'tag-aligned', nonEmpty: 'after-props' }
+    ],
+    'react/jsx-equals-spacing': [2, 'never'],
+    'react/jsx-first-prop-new-line': [2, 'multiline'],
+    'react/jsx-indent': [2, 2],
+    'react/jsx-indent-props': [2, 2],
+    'react/jsx-tag-spacing': [
+      2,
+      {
+        beforeSelfClosing: 'always'
+      }
+    ]
+  },
+  plugins: ['react']
+};


### PR DESCRIPTION
## Change
Some Eslint rules overlap with Prettier.
We previously removed rules that should be enforced by Prettier from eslint in
https://github.com/seek-oss/eslint-config-sku/pull/3

This change adds the rules back in under a separate config.

Using this feature should not be recommended, using Prettier is the recommended solution.

## Naming
I'm unsure what the config feature should be called.
It's currently names 'unpretty' to refer to the reason why you would want the config (because you don't use prettier). Other options could be 'sku/format' to refer to the type of rules it would enable.
