### PR TITLE
fix(config): removed deprecated ecmaFeature.modules flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,10 +7,6 @@ module.exports = {
     sourceType: 'module'
   },
   root: true,
-  // See: https://github.com/babel/babel-eslint/issues/192
-  ecmaFeatures: {
-    modules: true
-  },
   env: {
     browser: true,
     node: true,


### PR DESCRIPTION
Remove `ecmaFeatures.modules` attribute relying on it's replacement `parserOptions.sourceType`.

Consumers using versions before **eslint 2** may experience issues, however currently **eslint 3** is a direct dependency so this situation is unlikely.
We may want to move eslint to a peer dependency but that is out of scope fo this change.

https://eslint.org/docs/user-guide/migrating-to-2.0.0#language-options

> The **ecmaFeatures.modules** flag has been replaced by a **sourceType** property under parserOptions which can be set to "script" (default) or "module" for ES6 modules.

ecmaFeatures.modules is only required for eslint version <2.0.0 which is no-longer supported.
  
Fixes: https://github.com/seek-oss/eslint-config-sku/issues/16