### PR TITLE
 fix(package): Move ESLint from dependencies to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,11 +33,12 @@
     "@commitlint/config-angular": "^3.1.1",
     "commitizen": "^2.9.6",
     "cz-conventional-changelog": "^2.0.0",
+    "eslint": "^4.13.1",
     "husky": "^0.14.3",
     "semantic-release": "^8.0.3"
   },
-  "peerDependency": {
-    "eslint": ">=3.14.1"
+  "peerDependencies": {
+    "eslint": ">=2.0.0"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "url": "https://github.com/seek-oss/eslint-config-sku/issues"
   },
   "scripts": {
+    "test": "eslint --config 'index.js' foo",
     "commit": "git-cz",
     "commitmsg": "commitlint -e -x '@commitlint/config-angular'",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
@@ -20,7 +21,6 @@
   "homepage": "https://github.com/seek-oss/eslint-config-sku#readme",
   "dependencies": {
     "babel-eslint": "^7.2.3",
-    "eslint": "^3.19.0",
     "eslint-config-prettier": "^2.3.0",
     "eslint-import-resolver-node": "^0.3.0",
     "eslint-plugin-css-modules": "^2.7.1",
@@ -35,6 +35,9 @@
     "cz-conventional-changelog": "^2.0.0",
     "husky": "^0.14.3",
     "semantic-release": "^8.0.3"
+  },
+  "peerDependency": {
+    "eslint": ">=3.14.1"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
Run eslint with the config to ensure the configuration is valid.
Eslint exits with exit code 1 on an invalid config.

BREAKING CHANGE: Removed support for eslint versions <2.0.0. Please upgrade to a newer version or add `ecmaFeatures.modules` to your override