### PR TITLE
build: Rename to eslint-config-seek

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-[![Build Status](https://img.shields.io/travis/seek-oss/eslint-config-sku/master.svg?style=flat-square)](http://travis-ci.org/seek-oss/eslint-config-sku) [![npm](https://img.shields.io/npm/v/eslint-config-sku.svg?style=flat-square)](https://www.npmjs.com/package/eslint-config-sku) [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=flat-square)](https://github.com/semantic-release/semantic-release) [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg?style=flat-square)](http://commitizen.github.io/cz-cli/)
+[![Build Status](https://img.shields.io/travis/seek-oss/eslint-config-seek/master.svg?style=flat-square)](http://travis-ci.org/seek-oss/eslint-config-seek) [![npm](https://img.shields.io/npm/v/eslint-config-seek.svg?style=flat-square)](https://www.npmjs.com/package/eslint-config-seek) [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=flat-square)](https://github.com/semantic-release/semantic-release) [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg?style=flat-square)](http://commitizen.github.io/cz-cli/)
 
 
-# eslint-config-sku
+# eslint-config-seek
 
-This package includes the shareable ESLint configuration used by [sku](https://github.com/seek-oss/sku).
+This package includes the shareable ESLint configuration used by [SEEK](https://github.com/seek-oss/).
 
 ## Usage in sku Projects
 
@@ -21,11 +21,11 @@ Then create a file named `.eslintrc` with following contents in the root folder 
 
 ```js
 {
-  "extends": "sku"
+  "extends": "seek"
 }
 ```
 
-You can override the settings from `eslint-config-sku` by editing the `.eslintrc` file. Learn more about [configuring ESLint](http://eslint.org/docs/user-guide/configuring) on the ESLint website.
+You can override the settings from `eslint-config-seek` by editing the `.eslintrc` file. Learn more about [configuring ESLint](http://eslint.org/docs/user-guide/configuring) on the ESLint website.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "eslint-config-sku",
+  "name": "eslint-config-seek",
   "version": "0.0.0-development",
-  "description": "ESLint configuration used by SKU",
+  "description": "ESLint configuration used by SEEK",
   "main": "index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/seek-oss/eslint-config-sku.git"
+    "url": "git+https://github.com/seek-oss/eslint-config-seek.git"
   },
   "author": "Seek",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/seek-oss/eslint-config-sku/issues"
+    "url": "https://github.com/seek-oss/eslint-config-seek/issues"
   },
   "scripts": {
     "test": "eslint --config 'index.js' foo",
@@ -18,7 +18,7 @@
     "commitmsg": "commitlint -e -x '@commitlint/config-angular'",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
-  "homepage": "https://github.com/seek-oss/eslint-config-sku#readme",
+  "homepage": "https://github.com/seek-oss/eslint-config-seek#readme",
   "dependencies": {
     "babel-eslint": "^7.2.3",
     "eslint-config-prettier": "^2.3.0",


### PR DESCRIPTION
This change will rename `eslint-config-sku` to `eslint-config-seek`, better representing it's use  outside [sku](https://github.com/seek-oss/sku) based projects.

# Rename process
In order to rename this module we'll be following the [semantic-release renaming guide](https://github.com/semantic-release/semantic-release/wiki/Renaming-a-module)

1. Pull down latest `rename-to-seek` branch locally
2. Set package.json version to `v2.0.1`
3. Apply deploy credentials locally. Run `npm publish` from local machine.
4. Reset package.json version to `0.0.0_development`
5. Merge this PR
This final step will create a new major version release of `v3.0.0`


Last version of `eslint-config-sku`: `v2.0.1`
First version of `eslint-config-seek`: `v2.0.1`
First modified version of eslint-config-seek: `v3.0.0`

## Post migration
Once the new package is confirmed deployed deprecate `eslint-config-sku` with message 'eslint-config-sku has been renamed to eslint-config-seek'.
https://docs.npmjs.com/cli/deprecate

# Commit message for review

BREAKING CHANGE:
Replace all use of sku with seek.
### Before
.eslintconfig
```json
{
  "extend": ["sku"]
}
```
### After
.eslintconfig
```json
{
  "extend": ["seek"]
}
```
  
  