### PR TITLE
Remove `Install latest npm` step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,10 +78,6 @@ jobs:
       - name: Build
         run: pnpm build
 
-      # Ensure npm 11.5.1 or later is installed
-      - name: Install latest npm
-        run: npm install -g npm@latest
-
       - name: Publish
         uses: seek-oss/changesets-snapshot@v0
         env:


### PR DESCRIPTION
## Summary

- Removes the `Install latest npm` step from the release workflow.

Node.js now ships with an up-to-date version of npm, making this step unnecessary. Additionally, npm 12 has broken our release workflows, so explicitly upgrading to the latest npm is now harmful rather than helpful.

Made with [Cursor](https://cursor.com)